### PR TITLE
Disable Android Studio first run assistant

### DIFF
--- a/src/usr/bin/bbqlinux-livemedia-userconf
+++ b/src/usr/bin/bbqlinux-livemedia-userconf
@@ -4,4 +4,7 @@
 gsettings set org.mate.screensaver lock-enabled false
 gsettings set org.mate.screensaver idle-activation-enabled false
 
+# Disable Android Studio first run assistant
+echo disable.android.first.run=true >> /opt/android-studio/bin/idea.properties
+
 exit 0


### PR DESCRIPTION
Disable the Android Studio first run assistant that tries to download stuff which is not wanted on a Live system because it uses up all of the available cowspace
